### PR TITLE
Changing ACDB ID from 15 to 14 for SPEAKERS

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -29,11 +29,11 @@
         <!-- Output devices -->
         <device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="9"/>
         <device name="SND_DEVICE_OUT_LINE" acdb_id="77"/>
-        <device name="SND_DEVICE_OUT_SPEAKER" acdb_id="15"/>
+        <device name="SND_DEVICE_OUT_SPEAKER" acdb_id="14"/>
         <device name="SND_DEVICE_OUT_SPEAKER_AND_HDMI" acdb_id="18"/>
         <device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" acdb_id="10"/>
         <device name="SND_DEVICE_OUT_SPEAKER_AND_LINE" acdb_id="77"/>
-        <device name="SND_DEVICE_OUT_SPEAKER_REVERSE" acdb_id="15"/>
+        <device name="SND_DEVICE_OUT_SPEAKER_REVERSE" acdb_id="14"/>
         <device name="SND_DEVICE_OUT_VOICE_LINE" acdb_id="22"/>
 
         <!-- Input devices -->


### PR DESCRIPTION
While using ID 15 the sound was pretty quiet and rising the volume above ~60% creates distortion.
I propose (and tested) using ID 14 instead, which gives the adeguate amount of loudness , even using lower %Volume, but most important it doesn't distort anymore (not even at 100% volume!). Quality wise is much better, what seems to me like a reverb effect is added giving a more "room-full" sounding.